### PR TITLE
fix library path for darwin systems

### DIFF
--- a/lib3mf/__init__.py
+++ b/lib3mf/__init__.py
@@ -49,7 +49,7 @@ def get_library_path_for_wrapper():
             return lib_path[:-4]
     if system == "darwin":
         if str(lib_path).endswith(".dylib"):
-            return lib_path[-6]
+            return lib_path[:-6]
 
 # Your existing logic to use the library
 def get_wrapper():


### PR DESCRIPTION
I was running into this error during initialization:
```
OSError: dlopen(..dylib, 0x0006): tried: '..dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS..dylib' (no such file), '/opt/homebrew/lib/..dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/lib/..dylib' (no such file), '/usr/lib/..dylib' (no such file, not in dyld cache), '..dylib' (no such file), '/usr/local/lib/..dylib' (no such file), '/usr/lib/..dylib' (no such file, not in dyld cache)
```
This was because `lib_path[-6]` returns `.` and lib3mf_python was trying to open `.` + `.dylib`.