### PR TITLE
Don't access the network in Python setup

### DIFF
--- a/README-base.md
+++ b/README-base.md
@@ -1,0 +1,141 @@
+# lib3mf
+
+[![Build Status]](https://github.com/3MFConsortium/lib3mf/workflows/Build/badge.svg?branch=release%2F2.4.1)
+[![Documentation Status](https://readthedocs.org/projects/lib3mf/badge/?version=master)](https://readthedocs.org/projects/lib3mf)
+[![Version 2.4.1](https://img.shields.io/static/v1.svg?label=lib3mf&message=v2.4.1&color=green)]()
+[![Supported platforms](https://img.shields.io/static/v1.svg?label=platform&message=windows%20%7C%20macos%20%7C%20linux&color=lightgrey)]()
+[![Simplified BSD License](https://img.shields.io/static/v1.svg?label=license&message=BSD&color=green)](LICENSE)
+[![codecov](https://codecov.io/gh/3MFConsortium/lib3mf/branch/develop/graph/badge.svg?token=3ARnBye33c)](https://codecov.io/gh/3MFConsortium/lib3mf)
+
+lib3mf is a C++ implementation of the 3D Manufacturing Format file standard.
+
+It provides 3MF reading and writing capabilities, as well as conversion and validation tools for input and output data.
+lib3mf runs on Windows, Linux and MacOS and offers a clean and easy-to-use API in
+[various programming languages](https://lib3mf.readthedocs.io/en/latest/#api-documentation)
+to speed up the development and keep integration costs at a minimum.
+
+As 3MF shall become an universal 3D Printing standard, its quick adoption is very important. 
+This library shall lower all barriers of adoption to any possible user, let it be software 
+providers, hardware providers, service providers or middleware tools.
+
+The specification can be downloaded at
+[http://3mf.io/specification/](http://3mf.io/specification/).
+
+
+
+
+## Example (Create Cube)
+
+```python
+import lib3mf
+from lib3mf import get_wrapper
+
+# Get version
+def get_version(wrapper):
+    major, minor, micro = wrapper.GetLibraryVersion()
+    print("Lib3MF version: {:d}.{:d}.{:d}".format(major, minor, micro), end="")
+    hasInfo, prereleaseinfo = wrapper.GetPrereleaseInformation()
+    if hasInfo:
+        print("-" + prereleaseinfo, end="")
+    hasInfo, buildinfo = wrapper.GetBuildInformation()
+    if hasInfo:
+        print("+" + buildinfo, end="")
+    print("")
+
+
+# Create vertex in a mesh
+def create_vertex(_mesh, x, y, z):
+    position = lib3mf.Position()
+    position.Coordinates[0] = float(x)
+    position.Coordinates[1] = float(y)
+    position.Coordinates[2] = float(z)
+    _mesh.AddVertex(position)
+    return position
+
+
+# Add triangle in a mesh
+def add_triangle(_mesh, p1, p2, p3):
+    triangle = lib3mf.Triangle()
+    triangle.Indices[0] = p1
+    triangle.Indices[1] = p2
+    triangle.Indices[2] = p3
+    _mesh.AddTriangle(triangle)
+    return triangle
+
+
+# Get a wrapper object
+wrapper = get_wrapper()
+
+# Check version always
+get_version(wrapper)
+
+# Create a model
+model = wrapper.CreateModel()
+mesh_object = model.AddMeshObject()
+mesh_object.SetName("Box")
+
+# Define the size of the cube
+fSizeX, fSizeY, fSizeZ = 100.0, 200.0, 300.0
+
+# Create vertices
+vertices = [
+    create_vertex(mesh_object, 0, 0, 0),
+    create_vertex(mesh_object, fSizeX, 0, 0),
+    create_vertex(mesh_object, fSizeX, fSizeY, 0),
+    create_vertex(mesh_object, 0, fSizeY, 0),
+    create_vertex(mesh_object, 0, 0, fSizeZ),
+    create_vertex(mesh_object, fSizeX, 0, fSizeZ),
+    create_vertex(mesh_object, fSizeX, fSizeY, fSizeZ),
+    create_vertex(mesh_object, 0, fSizeY, fSizeZ)
+]
+
+# Define triangles by vertices indices
+triangle_indices = [
+    (2, 1, 0), (0, 3, 2), (4, 5, 6), (6, 7, 4),
+    (0, 1, 5), (5, 4, 0), (2, 3, 7), (7, 6, 2),
+    (1, 2, 6), (6, 5, 1), (3, 0, 4), (4, 7, 3)
+]
+
+# Create triangles
+triangles = []
+for v0, v1, v2 in triangle_indices:
+    triangles.append(add_triangle(mesh_object, v0, v1, v2))
+
+# Set geometry to the mesh object after creating vertices and triangles
+mesh_object.SetGeometry(vertices, triangles)
+
+# Add build item with an identity transform
+model.AddBuildItem(mesh_object, wrapper.GetIdentityTransform())
+
+# Save the model to a 3MF file
+writer = model.QueryWriter("3mf")
+writer.WriteToFile("cube.3mf")
+```
+
+## Documentation
+lib3mf's documentation is available on https://lib3mf.readthedocs.io.
+
+## Obtaining lib3mf
+Simply download the precompiled binary SDK https://github.com/3MFConsortium/lib3mf/releases.
+
+## Using lib3mf
+Allthough the different language bindings are kept as similar as possible,
+the usage of lib3mf still depends your programming language.
+
+You are best-off starting with one of the examples distributed in the [SDK](https://github.com/3MFConsortium/lib3mf/releases) or with this [minimal example in C++](SDK/Examples/CppDynamic/Source/ExtractInfo.cpp).
+
+## Contributing
+lib3mf is an open source project and supported by the [3MF Consortium](https://3mf.io/).
+
+Contributions are welcome and we are always looking for people that improve the implementation of the specification and extensions of 3MF. Have a look at the [contributor's guide](CONTRIBUTING.md) for details.
+This page also contains a section about building lib3mf from source or obtaining nightly snapshot builds.
+
+## Licenses and third party code
+lib3mf is released under the [BSD license](LICENSE). The library contains code of the following [third parties](SDK/Credits.txt):
+1. libzip 1.10.1, https://libzip.org/license/
+2. zlib 1.3.1, http://www.zlib.net/zlib_license.html
+3. cpp-base64 2.rc.08, https://github.com/ReneNyffenegger/cpp-base64/blob/master/LICENSE
+4. fast-float v6.0.0, https://github.com/fastfloat/fast_float/tree/v6.0.0?tab=License-3-ov-file
+
+In addition, the automated tests of lib3mf make uses of LibReSSL 3.8.2, [License](https://github.com/libressl/openbsd/blob/master/src/lib/libssl/LICENSE) and googletest 1.14.0 [License](https://github.com/google/googletest/blob/main/LICENSE). 
+

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import setup, find_packages
 import os
 import sys
 import platform
-import requests
 
 # Function to find the real path of the shared library
 def find_real_lib_path():
@@ -38,28 +37,8 @@ if current_platform not in SUPPORTED_PLATFORMS or current_arch not in SUPPORTED_
         f"This package only supports Linux (amd64), Windows (x86_64), and macOS (universal). "
         f"Your platform ({current_platform} {current_arch}) is not supported."
     )
-
-# Function to download a file from a URL
-def download_file(url):
-    response = requests.get(url)
-    if response.status_code == 200:
-        return response.text
-    else:
-        raise Exception(f"Failed to download file from {url}")
-
-# Download the README file
-readme_url = "https://raw.githubusercontent.com/3MFConsortium/lib3mf/release/2.4.1/README.md"
-readme_content = download_file(readme_url)
-
-# Read the example script content
-with open("create_cube_example_complete.py", "r", encoding="utf-8") as file:
-    create_cube_example_complete = file.read()
-
-# Insert the example before the documentation section
-readme_parts = readme_content.split("## Documentation")
-readme_content = readme_parts[0] + "\n\n## Example (Create Cube)\n\n```python\n" + create_cube_example_complete + "\n```\n\n## Documentation" + readme_parts[1]
-
-print(readme_content)
+with open("README-base.md","r") as file:
+    readme_content = file.read()
 
 # Setup script
 setup(


### PR DESCRIPTION
Network access may not work if the build process is sandboxed, which is what Linux distributions habitually do.

Instead, download the base README when the release is prepared.